### PR TITLE
zip management

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@ Optional fields are not outputted if empty, if default values are used, the writ
 
 ## Known restrictions
 
-Direct output to ZIP files not supported at the moment.
+For direct output in ZIP file, you must create it before: 
+
+    // do stuff with feed
+    os.Create("/path/to/output.zip")
+    
+    w := gtfswriter.Writer{}
+    werror := w.Write(feed, "/path/to/output")
 
 ## License
 


### PR DESCRIPTION
Hi 
I propose this modification to support direct write in zip file, but trying to change the code only a few. 

I'd like to write a function like : 
func (w *Writer) WriteInFile(feed *gtfsparser.Feed, file *os.File)
So this this the caller to decide to manage the file access/creation (or directory creation).
But this whould change the code a lot... 
